### PR TITLE
Added nullcheck for response content.

### DIFF
--- a/src/Verify.Http/RecordingHandler.cs
+++ b/src/Verify.Http/RecordingHandler.cs
@@ -42,9 +42,12 @@ public class RecordingHandler :
 
         var responseContent = response.Content;
         string? responseText = null;
-        if (responseContent.IsText())
+        if (responseContent != null)
         {
-            responseText = await responseContent.ReadAsStringAsync();
+            if (responseContent.IsText())
+            {
+                responseText = await responseContent.ReadAsStringAsync();
+            }
         }
 
         var item = new LoggedSend(


### PR DESCRIPTION
Added nullcheck for response.Content. I ran into this problem using netcore3.1.

According to [github issue](https://github.com/dotnet/runtime/issues/35859) it is not nullable anymore >= net5