### PR TITLE
Curstom content retriever when recording

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -57,7 +57,7 @@ public class MyService
     }
 }
 ```
-<sup><a href='/src/Tests/Tests.cs#L36-L56' title='Snippet source file'>snippet source</a> | <a href='#snippet-servicethatdoeshttp' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Tests/Tests.cs#L39-L59' title='Snippet source file'>snippet source</a> | <a href='#snippet-servicethatdoeshttp' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 
@@ -85,7 +85,7 @@ await Verify(recording.Sends)
     // Ignore some headers that change per request
     .ModifySerialization(x => x.IgnoreMembers("Date"));
 ```
-<sup><a href='/src/Tests/Tests.cs#L148-L167' title='Snippet source file'>snippet source</a> | <a href='#snippet-httpclientrecording' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Tests/Tests.cs#L151-L170' title='Snippet source file'>snippet source</a> | <a href='#snippet-httpclientrecording' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 
@@ -114,7 +114,7 @@ await Verify(recording.Sends)
     // Ignore some headers that change per request
     .ModifySerialization(x => x.IgnoreMembers("Date"));
 ```
-<sup><a href='/src/Tests/Tests.cs#L124-L142' title='Snippet source file'>snippet source</a> | <a href='#snippet-httpclientrecordingglobal' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Tests/Tests.cs#L127-L145' title='Snippet source file'>snippet source</a> | <a href='#snippet-httpclientrecordingglobal' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 
@@ -170,7 +170,7 @@ await myService.MethodThatDoesHttp();
 await Verify(recording.Sends)
     .ModifySerialization(x => x.IgnoreMembers("Date"));
 ```
-<sup><a href='/src/Tests/Tests.cs#L225-L249' title='Snippet source file'>snippet source</a> | <a href='#snippet-httpclientpauseresume' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Tests/Tests.cs#L234-L258' title='Snippet source file'>snippet source</a> | <a href='#snippet-httpclientpauseresume' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 If the `AddRecordingHttpClient` helper method does not meet requirements, the `RecordingHandler` can be explicitly added:
@@ -201,7 +201,7 @@ await client.GetAsync("https://httpbin.org/status/undefined");
 await Verify(recording.Sends)
     .ModifySerialization(x => x.IgnoreMembers("Date"));
 ```
-<sup><a href='/src/Tests/Tests.cs#L255-L280' title='Snippet source file'>snippet source</a> | <a href='#snippet-httpclientrecordingexplicit' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Tests/Tests.cs#L264-L289' title='Snippet source file'>snippet source</a> | <a href='#snippet-httpclientrecordingexplicit' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 
@@ -249,7 +249,7 @@ static async Task<int> MethodThatDoesHttpCalls()
     return jsonResult.Length + xmlResult.Length;
 }
 ```
-<sup><a href='/src/Tests/Tests.cs#L60-L90' title='Snippet source file'>snippet source</a> | <a href='#snippet-httprecording' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Tests/Tests.cs#L63-L93' title='Snippet source file'>snippet source</a> | <a href='#snippet-httprecording' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 The requests/response pairs will be appended to the verified file.
@@ -372,7 +372,7 @@ public async Task TestHttpRecordingExplicit()
         });
 }
 ```
-<sup><a href='/src/Tests/Tests.cs#L92-L119' title='Snippet source file'>snippet source</a> | <a href='#snippet-httprecordingexplicit' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Tests/Tests.cs#L95-L122' title='Snippet source file'>snippet source</a> | <a href='#snippet-httprecordingexplicit' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Results in the following:

--- a/src/Tests/Tests.ApplicationJson_ShouldBeRecorded_WithCustomContentRetriever.verified.txt
+++ b/src/Tests/Tests.ApplicationJson_ShouldBeRecorded_WithCustomContentRetriever.verified.txt
@@ -1,0 +1,26 @@
+﻿{
+  Recorded: [
+    {
+      RequestUri: https://httpbin.org/get,
+      RequestMethod: GET,
+      ResponseStatus: OK,
+      ResponseContent: { "age": 1234 }
+    }
+  ],
+  HttpResponse: {
+    Version: 1.1,
+    StatusCode: OK,
+    IsSuccessStatusCode: true,
+    ReasonPhrase: OK,
+    Content: {
+      Headers: {
+        Content-Length: 15,
+        Content-Type: application/json; charset=utf-8
+      },
+      Value: {
+        age: 1234
+      }
+    },
+    Request: null
+  }
+}

--- a/src/Tests/Tests.ApplicationJson_ShouldNotBeRecorded_WithDefaultContentRetriever.verified.txt
+++ b/src/Tests/Tests.ApplicationJson_ShouldNotBeRecorded_WithDefaultContentRetriever.verified.txt
@@ -1,0 +1,25 @@
+﻿{
+  Recorded: [
+    {
+      RequestUri: https://httpbin.org/get,
+      RequestMethod: GET,
+      ResponseStatus: OK
+    }
+  ],
+  HttpResponse: {
+    Version: 1.1,
+    StatusCode: OK,
+    IsSuccessStatusCode: true,
+    ReasonPhrase: OK,
+    Content: {
+      Headers: {
+        Content-Length: 15,
+        Content-Type: application/json; charset=utf-8
+      },
+      Value: {
+        age: 1234
+      }
+    },
+    Request: null
+  }
+}

--- a/src/Tests/Tests.MediaTypeTexPlain_ShouldBeRecorded_WithDefaultContentRetriever.verified.txt
+++ b/src/Tests/Tests.MediaTypeTexPlain_ShouldBeRecorded_WithDefaultContentRetriever.verified.txt
@@ -1,0 +1,24 @@
+﻿{
+  Recorded: [
+    {
+      RequestUri: https://httpbin.org/get,
+      RequestMethod: GET,
+      ResponseStatus: OK,
+      ResponseContent: string content 123
+    }
+  ],
+  HttpResponse: {
+    Version: 1.1,
+    StatusCode: OK,
+    IsSuccessStatusCode: true,
+    ReasonPhrase: OK,
+    Content: {
+      Headers: {
+        Content-Length: 18,
+        Content-Type: text/plain; charset=utf-8
+      },
+      Value: string content 123
+    },
+    Request: null
+  }
+}

--- a/src/Verify.Http/RecordingHandler.cs
+++ b/src/Verify.Http/RecordingHandler.cs
@@ -3,6 +3,9 @@
 public class RecordingHandler :
     DelegatingHandler
 {
+    private Func<HttpContent?, Task<string?>> _customRequestContentRetriever = DefaultIsTextContentRetriever;
+    private Func<HttpContent?, Task<string?>> _customResponseContentRetriever = DefaultIsTextContentRetriever;
+
     public ConcurrentQueue<LoggedSend> Sends = new();
 
     public void Resume()
@@ -22,33 +25,29 @@ public class RecordingHandler :
 
     public bool Recording { get; private set; }
 
+    public void SetCustomRequestContentRetriever(Func<HttpContent?, Task<string?>> func)
+    {
+        _customRequestContentRetriever = func ?? throw new ArgumentNullException(nameof(func));
+    }
+
+    public void SetCustomResponseContentRetriever(Func<HttpContent?, Task<string?>> func)
+    {
+        _customResponseContentRetriever = func ?? throw new ArgumentNullException(nameof(func));
+    }
+
     protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellation)
     {
         if (!Recording)
         {
             return await base.SendAsync(request, cancellation);
         }
-        string? requestText = null;
+ 
         var requestContent = request.Content;
-        if (requestContent != null)
-        {
-            if (requestContent.IsText())
-            {
-                requestText = await requestContent.ReadAsStringAsync();
-            }
-        }
-
+        var requestText = await _customRequestContentRetriever.Invoke(requestContent);
         var response = await base.SendAsync(request, cancellation);
 
         var responseContent = response.Content;
-        string? responseText = null;
-        if (responseContent != null)
-        {
-            if (responseContent.IsText())
-            {
-                responseText = await responseContent.ReadAsStringAsync();
-            }
-        }
+        var responseText = await _customResponseContentRetriever.Invoke(responseContent);
 
         var item = new LoggedSend(
             request.RequestUri,
@@ -64,5 +63,16 @@ public class RecordingHandler :
         Sends.Enqueue(item);
 
         return response;
+    }
+
+    private static async Task<string?> DefaultIsTextContentRetriever(HttpContent? content)
+    {
+        if (content == null)
+            return null;
+
+        if (!content.IsText())
+            return null;
+
+        return await content.ReadAsStringAsync();
     }
 }


### PR DESCRIPTION
Our team uses VerifyHttp to record and verify http calls and reponses. We ran into the issue that Verify.Http doesn't record the content when the contenttype is `application/json`.

This pull request contains a feature that the implementor has control over when and how to resolve the http request and http response content when recording.