### PR TITLE
fix: treat content with custom json mediaType as json

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -50,7 +50,7 @@ public async Task HttpResponse()
     await Verify(result);
 }
 ```
-<sup><a href='/src/Tests/Tests.cs#L231-L241' title='Snippet source file'>snippet source</a> | <a href='#snippet-httpresponse' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Tests/Tests.cs#L233-L243' title='Snippet source file'>snippet source</a> | <a href='#snippet-httpresponse' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Results in:
@@ -140,7 +140,7 @@ await Verify(recording.Sends)
     // Ignore some headers that change per request
     .ModifySerialization(x => x.IgnoreMembers("Date"));
 ```
-<sup><a href='/src/Tests/Tests.cs#L169-L188' title='Snippet source file'>snippet source</a> | <a href='#snippet-httpclientrecording' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Tests/Tests.cs#L171-L190' title='Snippet source file'>snippet source</a> | <a href='#snippet-httpclientrecording' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 
@@ -169,7 +169,7 @@ await Verify(recording.Sends)
     // Ignore some headers that change per request
     .ModifySerialization(x => x.IgnoreMembers("Date"));
 ```
-<sup><a href='/src/Tests/Tests.cs#L143-L161' title='Snippet source file'>snippet source</a> | <a href='#snippet-httpclientrecordingglobal' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Tests/Tests.cs#L145-L163' title='Snippet source file'>snippet source</a> | <a href='#snippet-httpclientrecordingglobal' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 
@@ -224,7 +224,7 @@ await myService.MethodThatDoesHttp();
 await Verify(recording.Sends)
     .ModifySerialization(x => x.IgnoreMembers("Date"));
 ```
-<sup><a href='/src/Tests/Tests.cs#L246-L270' title='Snippet source file'>snippet source</a> | <a href='#snippet-httpclientpauseresume' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Tests/Tests.cs#L248-L272' title='Snippet source file'>snippet source</a> | <a href='#snippet-httpclientpauseresume' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 If the `AddRecordingHttpClient` helper method does not meet requirements, the `RecordingHandler` can be explicitly added:
@@ -255,7 +255,7 @@ await client.GetAsync("https://httpbin.org/status/undefined");
 await Verify(recording.Sends)
     .ModifySerialization(x => x.IgnoreMembers("Date"));
 ```
-<sup><a href='/src/Tests/Tests.cs#L276-L301' title='Snippet source file'>snippet source</a> | <a href='#snippet-httpclientrecordingexplicit' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Tests/Tests.cs#L278-L303' title='Snippet source file'>snippet source</a> | <a href='#snippet-httpclientrecordingexplicit' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 
@@ -303,7 +303,7 @@ static async Task<int> MethodThatDoesHttpCalls()
     return jsonResult.Length + xmlResult.Length;
 }
 ```
-<sup><a href='/src/Tests/Tests.cs#L79-L109' title='Snippet source file'>snippet source</a> | <a href='#snippet-httprecording' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Tests/Tests.cs#L81-L111' title='Snippet source file'>snippet source</a> | <a href='#snippet-httprecording' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 The requests/response pairs will be appended to the verified file.
@@ -455,7 +455,7 @@ public async Task TestHttpRecordingExplicit()
         });
 }
 ```
-<sup><a href='/src/Tests/Tests.cs#L111-L138' title='Snippet source file'>snippet source</a> | <a href='#snippet-httprecordingexplicit' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Tests/Tests.cs#L113-L140' title='Snippet source file'>snippet source</a> | <a href='#snippet-httprecordingexplicit' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Results in the following:

--- a/src/Tests/MockHttpClientTests.GetJsonContent_mediaType=application-foo+json.DotNet6_0.verified.txt
+++ b/src/Tests/MockHttpClientTests.GetJsonContent_mediaType=application-foo+json.DotNet6_0.verified.txt
@@ -1,0 +1,12 @@
+﻿{
+  Version: 1.1,
+  Status: 200 OK,
+  Content: {
+    Headers: {
+      Content-Type: application/foo+json; charset=utf-8
+    },
+    Value: {
+      a: b
+    }
+  }
+}

--- a/src/Tests/MockHttpClientTests.GetJsonContent_mediaType=application-foo+json.Net4_8.verified.txt
+++ b/src/Tests/MockHttpClientTests.GetJsonContent_mediaType=application-foo+json.Net4_8.verified.txt
@@ -1,0 +1,12 @@
+﻿{
+  Version: 1.1,
+  Status: 200 OK,
+  Content: {
+    Headers: {
+      Content-Type: application/foo+json; charset=utf-8
+    },
+    Value: {
+      a: b
+    }
+  }
+}

--- a/src/Tests/MockHttpClientTests.GetJsonContent_mediaType=application-json.DotNet6_0.verified.txt
+++ b/src/Tests/MockHttpClientTests.GetJsonContent_mediaType=application-json.DotNet6_0.verified.txt
@@ -1,0 +1,12 @@
+﻿{
+  Version: 1.1,
+  Status: 200 OK,
+  Content: {
+    Headers: {
+      Content-Type: application/json; charset=utf-8
+    },
+    Value: {
+      a: b
+    }
+  }
+}

--- a/src/Tests/MockHttpClientTests.GetJsonContent_mediaType=application-json.Net4_8.verified.txt
+++ b/src/Tests/MockHttpClientTests.GetJsonContent_mediaType=application-json.Net4_8.verified.txt
@@ -1,0 +1,12 @@
+{
+  Version: 1.1,
+  Status: 200 OK,
+  Content: {
+    Headers: {
+      Content-Type: application/json; charset=utf-8
+    },
+    Value: {
+      a: b
+    }
+  }
+}

--- a/src/Tests/MockHttpClientTests.PostJsonContent_mediaType=application-foo+json.DotNet6_0.verified.txt
+++ b/src/Tests/MockHttpClientTests.PostJsonContent_mediaType=application-foo+json.DotNet6_0.verified.txt
@@ -1,0 +1,27 @@
+﻿{
+  result: {
+    Version: 1.1,
+    Status: 200 OK,
+    Content: {
+      Headers: {
+      }
+    }
+  },
+  client: {
+    Calls: [
+      {
+        Request: {
+          Method: POST,
+          Uri: https://fake/post,
+          ContentHeaders: {
+            Content-Type: application/foo+json
+          },
+          ContentStringParsed: {
+            a: b
+          }
+        },
+        Response: 200 Ok
+      }
+    ]
+  }
+}

--- a/src/Tests/MockHttpClientTests.PostJsonContent_mediaType=application-json.DotNet6_0.verified.txt
+++ b/src/Tests/MockHttpClientTests.PostJsonContent_mediaType=application-json.DotNet6_0.verified.txt
@@ -1,0 +1,27 @@
+﻿{
+  result: {
+    Version: 1.1,
+    Status: 200 OK,
+    Content: {
+      Headers: {
+      }
+    }
+  },
+  client: {
+    Calls: [
+      {
+        Request: {
+          Method: POST,
+          Uri: https://fake/post,
+          ContentHeaders: {
+            Content-Type: application/json
+          },
+          ContentStringParsed: {
+            a: b
+          }
+        },
+        Response: 200 Ok
+      }
+    ]
+  }
+}

--- a/src/Tests/MockHttpClientTests.PostJsonStringContent_mediaType=application-foo+json.DotNet6_0.verified.txt
+++ b/src/Tests/MockHttpClientTests.PostJsonStringContent_mediaType=application-foo+json.DotNet6_0.verified.txt
@@ -1,0 +1,27 @@
+﻿{
+  result: {
+    Version: 1.1,
+    Status: 200 OK,
+    Content: {
+      Headers: {
+      }
+    }
+  },
+  client: {
+    Calls: [
+      {
+        Request: {
+          Method: POST,
+          Uri: https://fake/post,
+          ContentHeaders: {
+            Content-Type: application/foo+json; charset=utf-8
+          },
+          ContentStringParsed: {
+            a: b
+          }
+        },
+        Response: 200 Ok
+      }
+    ]
+  }
+}

--- a/src/Tests/MockHttpClientTests.PostJsonStringContent_mediaType=application-foo+json.Net4_8.verified.txt
+++ b/src/Tests/MockHttpClientTests.PostJsonStringContent_mediaType=application-foo+json.Net4_8.verified.txt
@@ -1,0 +1,23 @@
+﻿{
+  result: {
+    Version: 1.1,
+    Status: 200 OK
+  },
+  client: {
+    Calls: [
+      {
+        Request: {
+          Method: POST,
+          Uri: https://fake/post,
+          ContentHeaders: {
+            Content-Type: application/foo+json; charset=utf-8
+          },
+          ContentStringParsed: {
+            a: b
+          }
+        },
+        Response: 200 Ok
+      }
+    ]
+  }
+}

--- a/src/Tests/MockHttpClientTests.PostJsonStringContent_mediaType=application-json.DotNet6_0.verified.txt
+++ b/src/Tests/MockHttpClientTests.PostJsonStringContent_mediaType=application-json.DotNet6_0.verified.txt
@@ -1,0 +1,27 @@
+﻿{
+  result: {
+    Version: 1.1,
+    Status: 200 OK,
+    Content: {
+      Headers: {
+      }
+    }
+  },
+  client: {
+    Calls: [
+      {
+        Request: {
+          Method: POST,
+          Uri: https://fake/post,
+          ContentHeaders: {
+            Content-Type: application/json; charset=utf-8
+          },
+          ContentStringParsed: {
+            a: b
+          }
+        },
+        Response: 200 Ok
+      }
+    ]
+  }
+}

--- a/src/Tests/MockHttpClientTests.PostJsonStringContent_mediaType=application-json.Net4_8.verified.txt
+++ b/src/Tests/MockHttpClientTests.PostJsonStringContent_mediaType=application-json.Net4_8.verified.txt
@@ -1,0 +1,23 @@
+{
+  result: {
+    Version: 1.1,
+    Status: 200 OK
+  },
+  client: {
+    Calls: [
+      {
+        Request: {
+          Method: POST,
+          Uri: https://fake/post,
+          ContentHeaders: {
+            Content-Type: application/json; charset=utf-8
+          },
+          ContentStringParsed: {
+            a: b
+          }
+        },
+        Response: 200 Ok
+      }
+    ]
+  }
+}

--- a/src/Tests/Tests.cs
+++ b/src/Tests/Tests.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
 using VerifyTests.Http;
 
 [UsesVerify]
@@ -63,12 +63,14 @@ public class Tests
         Assert.Equal(content, recordingHandler.Sends.Single().ResponseContent);
     }
 
-    [Fact]
-    public async Task MediaTypeApplicationJsonIsRecorded()
+    [Theory]
+    [InlineData("application/json")]
+    [InlineData("application/foo+json")]
+    public async Task MediaTypeApplicationJsonIsRecorded(string mediaType)
     {
         const string content = "{ \"age\": 1234 }";
         var recordingHandler = new RecordingHandler();
-        recordingHandler.InnerHandler = new ContentHandler(new(content, Encoding.UTF8, "application/json"));
+        recordingHandler.InnerHandler = new ContentHandler(new(content, Encoding.UTF8, mediaType));
         using var client = new HttpClient(recordingHandler);
 
         var response = await client.GetAsync("https://dont-care.org/get");


### PR DESCRIPTION
This enables verifying JSON content from HttpMessageResponse whose mediaType is on the form `application/XXX+json`, where XXX can be some text representing the custom JSON media type.