### PR TITLE
Added extensible resource descriptor (XRD) content type

### DIFF
--- a/src/Verify.Http/HttpExtensions.cs
+++ b/src/Verify.Http/HttpExtensions.cs
@@ -121,6 +121,7 @@ static class HttpExtensions
         {"application/x-x509-ca-cert", "cer"},
         {"application/x-zip-compressed", "zip"},
         {"application/xhtml+xml", "xhtml"},
+        {"application/xrd+xml", "xml"},
         {"application/xml", "xml"},
         {"audio/aac", "aac"},
         {"audio/aiff", "aiff"},


### PR DESCRIPTION
Defined in https://docs.oasis-open.org/ns/xri/xrd-1.0

Used by the Web Host Metadata [rfc6415](https://www.rfc-editor.org/rfc/rfc6415.html) as part of the Well Known standard [rfc5785](https://www.rfc-editor.org/rfc/rfc5785)

Content-Type: application/xrd+xml

Standard xml response.