### PR TITLE
docs: Note that `InitializePlugins()` must be called

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -14,6 +14,53 @@ Extends [Verify](https://github.com/VerifyTests/Verify) to allow verification of
 https://nuget.org/packages/Verify.Http/
 
 
+## Initialize
+
+Call `VerifierSettings.InitializePlugins()` in a `[ModuleInitializer]`. 
+
+<!-- snippet: ModuleInitializer.cs -->
+<a id='snippet-ModuleInitializer.cs'></a>
+```cs
+﻿public static class ModuleInit
+{
+    [ModuleInitializer]
+    public static void Initialize()
+    {
+        VerifierSettings.InitializePlugins();
+
+        VerifierSettings.IgnoreMembers(
+            "Content-Length",
+            "traceparent",
+            "Traceparent",
+            "X-Amzn-Trace-Id",
+            "X-GitHub-Request-Id",
+            "origin",
+            "Date",
+            "Server",
+            "X-Fastly-Request",
+            "Source-Age",
+            "X-Fastly-Request-ID",
+            "X-Served-By",
+            "X-Cache-Hits",
+            "X-Served-By",
+            "X-Cache",
+            "Content-Length",
+            "RequestHeaders",
+            "X-Timer",
+            "version",
+            "ETag");
+        VerifierSettings
+            .ScrubLinesContaining(
+                "Traceparent",
+                "Date",
+                "X-Amzn-Trace-Id",
+                "Content-Length");
+    }
+}
+```
+<sup><a href='/src/Tests/ModuleInitializer.cs#L1-L36' title='Snippet source file'>snippet source</a> | <a href='#snippet-ModuleInitializer.cs' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
 ## Enable
 
 Enable at any point in a test using `VerifyTests.Recording.Start()`.


### PR DESCRIPTION
I struggled to setup Verify.Http and follow the docs until I eventually found that I had to call `VerifierSettings.InitializePlugins();`. This PR adds documentation like in https://github.com/VerifyTests/Verify.DiffPlex which tells how to initialize the plugin.